### PR TITLE
Add link to shasta.tools in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align='center'>
-  <a href='shasta.tools'>
+  <a href='http://shasta.tools'>
     <img src='https://cloud.githubusercontent.com/assets/425716/12767211/d7fa856c-c9bc-11e5-82cb-99cf540330cb.png' width='400'/>
   </a>
   <p align='center'>Simple opinionated toolkit for building applications using React, Redux, and Immutable.js</p>
@@ -9,4 +9,4 @@
 
 There is sparse documentation, no tests, and it's not on npm. Read at your own risk while we finish up!
 
-Go to [shasta.tools](shasta.tools) for more information.
+Go to [shasta.tools](http://shasta.tools) for more information.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 <p align='center'>
-  <img src='https://cloud.githubusercontent.com/assets/425716/12767211/d7fa856c-c9bc-11e5-82cb-99cf540330cb.png' width='400'/>
+  <a href='shasta.tools'>
+    <img src='https://cloud.githubusercontent.com/assets/425716/12767211/d7fa856c-c9bc-11e5-82cb-99cf540330cb.png' width='400'/>
+  </a>
   <p align='center'>Simple opinionated toolkit for building applications using React, Redux, and Immutable.js</p>
 </p>
 
 ### You're early!
 
 There is sparse documentation, no tests, and it's not on npm. Read at your own risk while we finish up!
+
+Go to [shasta.tools](shasta.tools) for more information.


### PR DESCRIPTION
An interim solution to the problem raised in https://github.com/shastajs/shasta/pull/14 is to direct wanderers that come in through github first to the proper website.
